### PR TITLE
Add verbosity options

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -3,4 +3,5 @@
 use Mix.Config
 
 config :logger, :console,
-  level: :info
+  format: "$time $metadata[$level] $levelpad$message\n",
+  level: :warn

--- a/lib/cli.ex
+++ b/lib/cli.ex
@@ -7,7 +7,8 @@ defmodule Clone.CLI do
   require Logger
 
   def main(args \\ []) do
-    {options, words, _} = OptionParser.parse(args, switches: [debug: :boolean, verbose: :boolean])
+    {options, words, _} = OptionParser.parse(args, switches: [debug: :boolean, verbose: :boolean],
+                                                   aliases: [d: :debug, v: :verbose])
 
     set_verbosity(options)
 

--- a/lib/cli.ex
+++ b/lib/cli.ex
@@ -7,20 +7,31 @@ defmodule Clone.CLI do
   require Logger
 
   def main(args \\ []) do
-    {_, words, _} = OptionParser.parse(args)
+    {options, words, _} = OptionParser.parse(args, switches: [debug: :boolean, verbose: :boolean])
+
+    set_verbosity(options)
 
     location = List.first(words)
+    Logger.debug(fn -> "location = #{location}" end)
     {owner, repo} = Repo.parse_location(location)
+    Logger.debug(fn -> "owner = #{owner}" end)
+    Logger.debug(fn -> "repo = #{repo}" end)
     home_dir = Path.expand(env(["REPO_HOME", "GITHUB_REPOS_HOME", "ATOM_REPOS_HOME"]))
+    Logger.debug(fn -> "home_dir = #{home_dir}" end)
     owner_dir = Path.join(home_dir, owner)
+    Logger.debug(fn -> "owner_dir = #{owner_dir}" end)
     repo_dir = Path.join(owner_dir, repo)
     Logger.debug(fn -> "repo_dir = #{repo_dir}" end)
 
     :ok = ensure_directory(owner_dir)
+
+    Logger.info(fn -> "Execute `hub clone #{location} #{repo_dir}`" end)
     System.cmd("hub", ["clone", location, repo_dir])
   end
 
   defp ensure_directory(dirname) do
+    Logger.debug(fn -> "Execute `mkdir #{dirname}` if necessary" end)
+
     case File.mkdir(dirname) do
       :ok -> :ok
       {:error, :eexist} -> :ok
@@ -38,5 +49,10 @@ defmodule Clone.CLI do
         true -> value
       end
     end)
+  end
+
+  defp set_verbosity(options) do
+    if Keyword.get(options, :verbose), do: Logger.configure_backend(:console, level: :info)
+    if Keyword.get(options, :debug), do: Logger.configure_backend(:console, level: :debug)
   end
 end


### PR DESCRIPTION
Adds a `--verbose` (aliased to `-v`) and `--debug` (aliased to `-d`) option that outputs logging information.