### PR TITLE
Create separate scripts for building and installing the escript

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If the tool cannot detect a reasonable value for `REPO_HOME`, it will log an err
 ## Installation
 
 1. Clone [the repository](https://github.com/lee-dohm/clone) to your local system
-1. Run `script/build`
+1. Run `script/install`
 
 ## License
 

--- a/script/build
+++ b/script/build
@@ -10,8 +10,6 @@ cd "$(dirname "$0")/.."
 
 script/test
 
-export MIX_ENV="prod"
+echo "==> Build escript…"
 
-echo "==> Build and install escript…"
-
-mix escript.install --force
+mix escript.build

--- a/script/install
+++ b/script/install
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# script/install: Build and install the escript.
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+[ -z "$DEBUG" ] || set -x
+
+script/test
+
+echo "==> Build and install escript…"
+
+export MIX_ENV="prod"
+
+mix escript.install --force


### PR DESCRIPTION
It's useful to be able to build a test version locally without overwriting the installed version.